### PR TITLE
Improve GEO and SEO metadata

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -63,7 +63,9 @@ const gaMeasurementId = import.meta.env.PUBLIC_GA_MEASUREMENT_ID
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={metaDescription} />
     {imageUrl && <meta name="twitter:image" content={imageUrl} />}
-    {schemaItems.map((schemaItem) => <script type="application/ld+json" set:html={JSON.stringify(schemaItem)} />)}
+    {schemaItems.map((schemaItem) => (
+      <script type="application/ld+json" set:html={JSON.stringify(schemaItem)}></script>
+    ))}
     {
       gaMeasurementId && (
         <>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -3,8 +3,37 @@ import "../styles/globals.css"
 import AgentationOverlay from "../components/AgentationOverlay"
 import SiteHeader from "../components/SiteHeader.astro"
 import SiteFooter from "../components/SiteFooter.astro"
+import { absoluteUrl, personSchema, SITE_DESCRIPTION, websiteSchema } from "../lib/seo"
 
-const { title, description } = Astro.props
+type SchemaItem = Record<string, unknown>
+
+interface Props {
+  title?: string
+  description?: string
+  canonical?: string
+  image?: string
+  type?: "website" | "article"
+  schema?: SchemaItem | SchemaItem[]
+}
+
+const {
+  title = "WOO HANNAH",
+  description,
+  canonical,
+  image,
+  type = "website",
+  schema,
+} = Astro.props as Props
+
+const weakDescriptions = new Set(["Artist Portfolio", "Works", "Exhibitions", "Press"])
+const metaDescription = description && !weakDescriptions.has(description) ? description : SITE_DESCRIPTION
+const canonicalUrl = canonical ? absoluteUrl(canonical) : absoluteUrl(Astro.url.pathname)
+const imageUrl = image ? absoluteUrl(image) : undefined
+const schemaItems = [
+  websiteSchema(),
+  personSchema(),
+  ...(Array.isArray(schema) ? schema : schema ? [schema] : []),
+]
 const gaMeasurementId = import.meta.env.PUBLIC_GA_MEASUREMENT_ID
 ---
 
@@ -13,6 +42,7 @@ const gaMeasurementId = import.meta.env.PUBLIC_GA_MEASUREMENT_ID
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="canonical" href={canonicalUrl} />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -20,7 +50,20 @@ const gaMeasurementId = import.meta.env.PUBLIC_GA_MEASUREMENT_ID
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&family=Noto+Sans+KR:wght@400;500;600;700;900&family=Playfair+Display:wght@900&display=swap"
     />
     <title>{title}</title>
-    {description && <meta name="description" content={description} />}
+    <meta name="description" content={metaDescription} />
+    <meta name="robots" content="index, follow" />
+    <meta property="og:site_name" content="WOO HANNAH" />
+    <meta property="og:locale" content="ko_KR" />
+    <meta property="og:type" content={type} />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={metaDescription} />
+    <meta property="og:url" content={canonicalUrl} />
+    {imageUrl && <meta property="og:image" content={imageUrl} />}
+    <meta name="twitter:card" content={imageUrl ? "summary_large_image" : "summary"} />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={metaDescription} />
+    {imageUrl && <meta name="twitter:image" content={imageUrl} />}
+    {schemaItems.map((schemaItem) => <script type="application/ld+json" set:html={JSON.stringify(schemaItem)} />)}
     {
       gaMeasurementId && (
         <>

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,154 @@
+import type { ContentEntry } from "./content"
+
+export const SITE_URL = "https://woohannah.com"
+export const ARTIST_NAME = "Woo Hannah"
+export const SITE_DESCRIPTION =
+  "Official portfolio of Woo Hannah, a contemporary artist working across sculpture, installation, painting, and textile-based mixed media."
+
+const ARTIST_ID = `${SITE_URL}/#artist`
+const WEBSITE_ID = `${SITE_URL}/#website`
+
+export const ARTIST_SAME_AS = [
+  "https://www.instagram.com/hannah.flashed.that/",
+  "https://www.artsy.net/artist/woo-hannah",
+  "https://ggallery.kr/artists/woo-hannah",
+  "https://www.frieze.com/article/frieze-seoul-2023-artist-award-woo-hannah",
+]
+
+export function absoluteUrl(pathname = ""): string {
+  if (/^https?:\/\//i.test(pathname)) return pathname
+  return new URL(pathname.replace(/^\/+/, ""), `${SITE_URL}/`).toString()
+}
+
+export function stripHtml(html = ""): string {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+export function truncateText(text: string, maxLen = 160): string {
+  if (text.length <= maxLen) return text
+  return `${text.slice(0, maxLen).replace(/\s\S*$/, "").trim()}...`
+}
+
+export function summarizeEntry(entry: ContentEntry, fallback?: string, maxLen = 160): string {
+  const summary = entry.description?.trim() || stripHtml(entry.bodyHtml) || fallback || `${entry.title} by ${ARTIST_NAME}.`
+  return truncateText(summary, maxLen)
+}
+
+export function entryPath(entry: ContentEntry): string {
+  const slug = entry.slug.join("/")
+  if (entry.type === "work") return `/works/${slug}/`
+  if (entry.type === "exhibition") return `/exhibitions/${slug}/`
+  if (entry.type === "thought") return `/thoughts/${slug}/`
+  return `/${slug}/`
+}
+
+export function entryUrl(entry: ContentEntry): string {
+  return absoluteUrl(entryPath(entry))
+}
+
+export function entryImageUrl(entry: ContentEntry): string | undefined {
+  return entry.thumbnail ? absoluteUrl(entry.thumbnail) : undefined
+}
+
+export function websiteSchema(): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "@id": WEBSITE_ID,
+    name: "WOO HANNAH",
+    url: SITE_URL,
+    description: SITE_DESCRIPTION,
+    inLanguage: ["ko", "en"],
+    publisher: { "@id": ARTIST_ID },
+  }
+}
+
+export function personSchema(): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "@id": ARTIST_ID,
+    name: ARTIST_NAME,
+    alternateName: ["WOO HANNAH", "Hannah Woo", "Woo Hannah", "우한나"],
+    birthDate: "1988",
+    jobTitle: "Artist",
+    url: SITE_URL,
+    sameAs: ARTIST_SAME_AS,
+    knowsAbout: ["Sculpture", "Installation art", "Textile art", "Contemporary art", "Mixed media"],
+  }
+}
+
+export function visualArtworkSchema(entry: ContentEntry): Record<string, unknown> {
+  return compactSchema({
+    "@context": "https://schema.org",
+    "@type": "VisualArtwork",
+    name: entry.title,
+    url: entryUrl(entry),
+    image: entryImageUrl(entry),
+    description: summarizeEntry(
+      entry,
+      [entry.title, "by Woo Hannah", entry.year, entry.medium].filter(Boolean).join(", "),
+    ),
+    creator: { "@id": ARTIST_ID },
+    artist: { "@id": ARTIST_ID },
+    dateCreated: entry.year,
+    artMedium: entry.medium,
+    material: entry.medium,
+    width: entry.dimensions,
+    mainEntityOfPage: entryUrl(entry),
+  })
+}
+
+export function exhibitionSchema(entry: ContentEntry): Record<string, unknown> {
+  return compactSchema({
+    "@context": "https://schema.org",
+    "@type": "ExhibitionEvent",
+    name: entry.title.replace(/^\d{4},\s*/, ""),
+    url: entryUrl(entry),
+    image: entryImageUrl(entry),
+    description: summarizeEntry(entry, `${entry.title}, an exhibition featuring work by Woo Hannah.`),
+    startDate: entry.date,
+    eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
+    eventStatus: "https://schema.org/EventScheduled",
+    performer: { "@id": ARTIST_ID },
+    about: { "@id": ARTIST_ID },
+    organizer: { "@id": ARTIST_ID },
+    mainEntityOfPage: entryUrl(entry),
+  })
+}
+
+export function articleSchema(entry: ContentEntry): Record<string, unknown> {
+  return compactSchema({
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: entry.title,
+    url: entryUrl(entry),
+    image: entryImageUrl(entry),
+    description: summarizeEntry(entry),
+    datePublished: entry.date,
+    dateModified: entry.date,
+    author: { "@id": ARTIST_ID },
+    publisher: { "@id": ARTIST_ID },
+    mainEntityOfPage: entryUrl(entry),
+    inLanguage: "ko",
+  })
+}
+
+function compactSchema(value: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, item]) => {
+      if (item === undefined || item === null || item === "") return false
+      if (Array.isArray(item) && item.length === 0) return false
+      return true
+    }),
+  )
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -103,7 +103,9 @@ export function visualArtworkSchema(entry: ContentEntry): Record<string, unknown
     dateCreated: entry.year,
     artMedium: entry.medium,
     material: entry.medium,
-    width: entry.dimensions,
+    additionalProperty: entry.dimensions
+      ? [{ "@type": "PropertyValue", name: "dimensions", value: entry.dimensions }]
+      : undefined,
     mainEntityOfPage: entryUrl(entry),
   })
 }

--- a/src/pages/exhibitions/[...slug].astro
+++ b/src/pages/exhibitions/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro"
 import { loadAllContent } from "../../lib/content"
+import { exhibitionSchema, summarizeEntry } from "../../lib/seo"
 
 export async function getStaticPaths() {
   const all = await loadAllContent()
@@ -9,9 +10,15 @@ export async function getStaticPaths() {
 }
 
 const { entry } = Astro.props
+const description = summarizeEntry(entry, `${entry.title}, an exhibition featuring work by Woo Hannah.`)
 ---
 
-<BaseLayout title={`${entry.title} · WOO HANNAH`} description={entry.description}>
+<BaseLayout
+  title={`${entry.title} · WOO HANNAH`}
+  description={description}
+  image={entry.thumbnail}
+  schema={exhibitionSchema(entry)}
+>
   <article class="prose prose-zinc max-w-none">
     <h1>{entry.title}</h1>
     <p class="mt-2 text-sm text-zinc-600">

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,49 @@
+import { loadAllContent, sortByDateDesc } from "../lib/content"
+import { ARTIST_NAME, SITE_DESCRIPTION, absoluteUrl, entryPath, summarizeEntry } from "../lib/seo"
+
+export async function GET() {
+  const all = await loadAllContent()
+  const works = sortByDateDesc(all.filter((entry) => entry.type === "work"))
+  const exhibitions = sortByDateDesc(all.filter((entry) => entry.type === "exhibition"))
+  const thoughts = sortByDateDesc(all.filter((entry) => entry.type === "thought"))
+
+  const body = [
+    `# WOO HANNAH`,
+    "",
+    `> ${SITE_DESCRIPTION}`,
+    "",
+    `Woo Hannah, also known as Hannah Woo and 우한나, is a contemporary artist working across sculpture, installation, painting, and textile-based mixed media.`,
+    "",
+    "## Core Pages",
+    "",
+    `- [Home](${absoluteUrl("/")}) - Official portfolio homepage for ${ARTIST_NAME}.`,
+    `- [About](${absoluteUrl("/about/")}) - Artist biography, CV, education, exhibitions, and awards.`,
+    `- [Works](${absoluteUrl("/works/")}) - Index of sculptures, installations, paintings, and series.`,
+    `- [Exhibitions](${absoluteUrl("/exhibitions/")}) - Solo, duo, and group exhibition archive.`,
+    `- [Thoughts](${absoluteUrl("/thoughts/")}) - Interviews, criticism, essays, and artist texts.`,
+    `- [Press](${absoluteUrl("/press/")}) - Press coverage and external references.`,
+    "",
+    "## Selected Works",
+    "",
+    ...works.slice(0, 24).map((entry) => formatEntry(entry)),
+    "",
+    "## Exhibitions",
+    "",
+    ...exhibitions.slice(0, 30).map((entry) => formatEntry(entry)),
+    "",
+    "## Writing and Press Context",
+    "",
+    ...thoughts.slice(0, 20).map((entry) => formatEntry(entry)),
+    "",
+  ].join("\n")
+
+  return new Response(body, {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  })
+}
+
+function formatEntry(entry: Awaited<ReturnType<typeof loadAllContent>>[number]): string {
+  const date = entry.date?.slice(0, 4) || entry.year
+  const label = date ? `${entry.title} (${date})` : entry.title
+  return `- [${label}](${absoluteUrl(entryPath(entry))}) - ${summarizeEntry(entry, `${entry.title} by Woo Hannah.`, 220)}`
+}

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -1,0 +1,24 @@
+import { SITE_URL } from "../lib/seo"
+
+export function GET() {
+  const body = [
+    "User-agent: *",
+    "Allow: /",
+    "",
+    "User-agent: GPTBot",
+    "Allow: /",
+    "",
+    "User-agent: ClaudeBot",
+    "Allow: /",
+    "",
+    "User-agent: PerplexityBot",
+    "Allow: /",
+    "",
+    `Sitemap: ${SITE_URL}/sitemap.xml`,
+    "",
+  ].join("\n")
+
+  return new Response(body, {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  })
+}

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,0 +1,47 @@
+import { loadAllContent, sortByDateDesc } from "../lib/content"
+import { absoluteUrl, entryPath } from "../lib/seo"
+
+const STATIC_PATHS = ["/", "/about/", "/works/", "/exhibitions/", "/thoughts/", "/press/"]
+
+export async function GET() {
+  const all = await loadAllContent()
+  const entries = sortByDateDesc(all.filter((entry) => entry.type === "work" || entry.type === "exhibition" || entry.type === "thought"))
+  const urls = new Map<string, string | undefined>()
+
+  for (const pathname of STATIC_PATHS) urls.set(pathname, undefined)
+  for (const entry of entries) urls.set(entryPath(entry), normalizedDate(entry.date))
+
+  const body = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${Array.from(urls.entries()).map(([pathname, lastmod]) => renderUrl(pathname, lastmod)).join("\n")}
+</urlset>
+`
+
+  return new Response(body, {
+    headers: { "Content-Type": "application/xml; charset=utf-8" },
+  })
+}
+
+function renderUrl(pathname: string, lastmod?: string): string {
+  return [
+    "  <url>",
+    `    <loc>${escapeXml(absoluteUrl(pathname))}</loc>`,
+    lastmod ? `    <lastmod>${lastmod}</lastmod>` : undefined,
+    "  </url>",
+  ].filter(Boolean).join("\n")
+}
+
+function normalizedDate(date?: string): string | undefined {
+  if (!date) return undefined
+  const match = date.match(/^\d{4}-\d{2}-\d{2}/)
+  return match?.[0]
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;")
+}

--- a/src/pages/thoughts/[...slug].astro
+++ b/src/pages/thoughts/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro"
 import { loadAllContent } from "../../lib/content"
+import { articleSchema, summarizeEntry } from "../../lib/seo"
 
 export async function getStaticPaths() {
   const all = await loadAllContent()
@@ -12,9 +13,16 @@ export async function getStaticPaths() {
 }
 
 const { entry } = Astro.props
+const description = summarizeEntry(entry)
 ---
 
-<BaseLayout title={`${entry.title} · WOO HANNAH`} description={entry.description}>
+<BaseLayout
+  title={`${entry.title} · WOO HANNAH`}
+  description={description}
+  image={entry.thumbnail}
+  type="article"
+  schema={articleSchema(entry)}
+>
   <article class="prose prose-zinc max-w-none">
     <h1>{entry.title}</h1>
     {entry.date && (

--- a/src/pages/works/[...slug].astro
+++ b/src/pages/works/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro"
 import { loadAllContent } from "../../lib/content"
+import { summarizeEntry, visualArtworkSchema } from "../../lib/seo"
 
 export async function getStaticPaths() {
   const all = await loadAllContent()
@@ -9,9 +10,18 @@ export async function getStaticPaths() {
 }
 
 const { entry } = Astro.props
+const description = summarizeEntry(
+  entry,
+  [entry.title, "by Woo Hannah", entry.year, entry.category, entry.medium].filter(Boolean).join(" · "),
+)
 ---
 
-<BaseLayout title={`${entry.title} · WOO HANNAH`} description={entry.description}>
+<BaseLayout
+  title={`${entry.title} · WOO HANNAH`}
+  description={description}
+  image={entry.thumbnail}
+  schema={visualArtworkSchema(entry)}
+>
   <article class="prose prose-zinc max-w-none work-detail">
     <h1>{entry.title}</h1>
     <p class="mt-2 text-sm text-zinc-600">


### PR DESCRIPTION
## Summary
- Add shared SEO/GEO helpers for canonical URLs, metadata descriptions, entity schema, and entry-specific schema.
- Add dynamic `robots.txt`, `sitemap.xml`, and `llms.txt` Astro endpoints without adding new dependencies.
- Attach `VisualArtwork`, `ExhibitionEvent`, and `Article` JSON-LD to work, exhibition, and thought detail pages.
- Expand global Open Graph, Twitter card, canonical, robots, `WebSite`, and `Person` metadata.

## Notes
- Based on the `geo-seo-claude` checklist style, but implemented directly in the Astro app instead of adding the external tool as a production dependency.
- The local shell in this Codex environment could not spawn `/bin/zsh`, `/bin/bash`, or `/bin/sh`, so I could not run `npm run build` locally. Changes were reviewed through GitHub file reads and compare diff only.

## Test Plan
- Not run: local shell execution is unavailable in the current environment.