### PR TITLE
Add structured navigation schema for SEO

### DIFF
--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -8,6 +8,18 @@ export const SITE_DESCRIPTION =
 const ARTIST_ID = `${SITE_URL}/#artist`
 const WEBSITE_ID = `${SITE_URL}/#website`
 
+type ListSchemaItem = {
+  name: string
+  url: string
+  description?: string
+  image?: string
+}
+
+type BreadcrumbItem = {
+  name: string
+  path: string
+}
+
 export const ARTIST_SAME_AS = [
   "https://www.instagram.com/hannah.flashed.that/",
   "https://www.artsy.net/artist/woo-hannah",
@@ -59,6 +71,15 @@ export function entryImageUrl(entry: ContentEntry): string | undefined {
   return entry.thumbnail ? absoluteUrl(entry.thumbnail) : undefined
 }
 
+export function entryListItem(entry: ContentEntry, maxDescriptionLen = 180): ListSchemaItem {
+  return compactSchema({
+    name: entry.title,
+    url: entryUrl(entry),
+    description: summarizeEntry(entry, `${entry.title} by Woo Hannah.`, maxDescriptionLen),
+    image: entryImageUrl(entry),
+  }) as ListSchemaItem
+}
+
 export function websiteSchema(): Record<string, unknown> {
   return {
     "@context": "https://schema.org",
@@ -106,6 +127,7 @@ export function visualArtworkSchema(entry: ContentEntry): Record<string, unknown
     additionalProperty: entry.dimensions
       ? [{ "@type": "PropertyValue", name: "dimensions", value: entry.dimensions }]
       : undefined,
+    isPartOf: { "@id": `${SITE_URL}/works/#collection` },
     mainEntityOfPage: entryUrl(entry),
   })
 }
@@ -124,6 +146,7 @@ export function exhibitionSchema(entry: ContentEntry): Record<string, unknown> {
     performer: { "@id": ARTIST_ID },
     about: { "@id": ARTIST_ID },
     organizer: { "@id": ARTIST_ID },
+    isPartOf: { "@id": `${SITE_URL}/exhibitions/#collection` },
     mainEntityOfPage: entryUrl(entry),
   })
 }
@@ -140,9 +163,85 @@ export function articleSchema(entry: ContentEntry): Record<string, unknown> {
     dateModified: entry.date,
     author: { "@id": ARTIST_ID },
     publisher: { "@id": ARTIST_ID },
+    isPartOf: { "@id": `${SITE_URL}/thoughts/#collection` },
     mainEntityOfPage: entryUrl(entry),
     inLanguage: "ko",
   })
+}
+
+export function breadcrumbSchema(items: BreadcrumbItem[]): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.name,
+      item: absoluteUrl(item.path),
+    })),
+  }
+}
+
+export function entryBreadcrumbSchema(entry: ContentEntry): Record<string, unknown> {
+  const section = entry.type === "work" ? "Works" : entry.type === "exhibition" ? "Exhibitions" : "Thoughts"
+  const sectionPath = entry.type === "work" ? "/works/" : entry.type === "exhibition" ? "/exhibitions/" : "/thoughts/"
+
+  return breadcrumbSchema([
+    { name: "Home", path: "/" },
+    { name: section, path: sectionPath },
+    { name: entry.title, path: entryPath(entry) },
+  ])
+}
+
+export function collectionPageSchema(options: {
+  name: string
+  description: string
+  path: string
+  id?: string
+  items?: ListSchemaItem[]
+}): Record<string, unknown> {
+  const url = absoluteUrl(options.path)
+  const items = options.items ?? []
+
+  return compactSchema({
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "@id": options.id ?? `${url}#collection`,
+    name: options.name,
+    url,
+    description: options.description,
+    about: { "@id": ARTIST_ID },
+    isPartOf: { "@id": WEBSITE_ID },
+    mainEntity: items.length
+      ? {
+          "@type": "ItemList",
+          numberOfItems: items.length,
+          itemListElement: items.map((item, index) =>
+            compactSchema({
+              "@type": "ListItem",
+              position: index + 1,
+              name: item.name,
+              url: item.url,
+              image: item.image,
+              description: item.description,
+            }),
+          ),
+        }
+      : undefined,
+  })
+}
+
+export function profilePageSchema(description: string): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ProfilePage",
+    "@id": `${SITE_URL}/about/#profile`,
+    name: "About Woo Hannah",
+    url: absoluteUrl("/about/"),
+    description,
+    mainEntity: { "@id": ARTIST_ID },
+    isPartOf: { "@id": WEBSITE_ID },
+  }
 }
 
 function compactSchema(value: Record<string, unknown>): Record<string, unknown> {

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -2,6 +2,7 @@
 import BaseLayout from "../layouts/BaseLayout.astro"
 import { loadAllContent } from "../lib/content"
 import { linkAboutExhibitions } from "../lib/exhibition-links"
+import { breadcrumbSchema, profilePageSchema, stripHtml, truncateText } from "../lib/seo"
 
 const all = await loadAllContent()
 const about = all.find((e) => e.type === "page" && e.slug.join("/") === "about")
@@ -13,13 +14,21 @@ if (!about) {
   throw new Error("About page not found in content/About.md")
 }
 
+const pageDescription = about.description ?? truncateText(stripHtml(about.englishHtml ?? about.bodyHtml), 180)
+const pageSchema = [
+  profilePageSchema(pageDescription),
+  breadcrumbSchema([
+    { name: "Home", path: "/" },
+    { name: "About", path: "/about/" },
+  ]),
+]
 const linkedBodyHtml = linkAboutExhibitions(about.bodyHtml, exhibitions, base)
 const linkedEnglishHtml = about.englishHtml
   ? linkAboutExhibitions(about.englishHtml, exhibitions, base)
   : undefined
 ---
 
-<BaseLayout title="About · WOO HANNAH" description={about.description}>
+<BaseLayout title="About · WOO HANNAH" description={pageDescription} schema={pageSchema}>
   <article class="about-page prose prose-zinc max-w-none">
     <h1>{about.title}</h1>
     

--- a/src/pages/exhibitions/[...slug].astro
+++ b/src/pages/exhibitions/[...slug].astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro"
 import { loadAllContent } from "../../lib/content"
-import { exhibitionSchema, summarizeEntry } from "../../lib/seo"
+import { entryBreadcrumbSchema, exhibitionSchema, summarizeEntry } from "../../lib/seo"
 
 export async function getStaticPaths() {
   const all = await loadAllContent()
@@ -11,13 +11,14 @@ export async function getStaticPaths() {
 
 const { entry } = Astro.props
 const description = summarizeEntry(entry, `${entry.title}, an exhibition featuring work by Woo Hannah.`)
+const pageSchema = [exhibitionSchema(entry), entryBreadcrumbSchema(entry)]
 ---
 
 <BaseLayout
   title={`${entry.title} · WOO HANNAH`}
   description={description}
   image={entry.thumbnail}
-  schema={exhibitionSchema(entry)}
+  schema={pageSchema}
 >
   <article class="prose prose-zinc max-w-none">
     <h1>{entry.title}</h1>

--- a/src/pages/exhibitions/index.astro
+++ b/src/pages/exhibitions/index.astro
@@ -1,9 +1,23 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro"
 import { loadAllContent, sortByDateDesc } from "../../lib/content"
+import { breadcrumbSchema, collectionPageSchema, entryListItem } from "../../lib/seo"
 
 const all = await loadAllContent()
 const exhibitions = sortByDateDesc(all.filter((e) => e.type === "exhibition"))
+const pageDescription = "Solo, duo, and group exhibition archive for Woo Hannah."
+const pageSchema = [
+  collectionPageSchema({
+    name: "Exhibitions by Woo Hannah",
+    description: pageDescription,
+    path: "/exhibitions/",
+    items: exhibitions.map((entry) => entryListItem(entry)),
+  }),
+  breadcrumbSchema([
+    { name: "Home", path: "/" },
+    { name: "Exhibitions", path: "/exhibitions/" },
+  ]),
+]
 const baseRaw = import.meta.env.BASE_URL
 const base = baseRaw.endsWith("/") ? baseRaw : `${baseRaw}/`
 
@@ -36,7 +50,7 @@ const categorySections = [
 ].filter((section) => section.items.length > 0)
 ---
 
-<BaseLayout title="Exhibitions · WOO HANNAH" description="Exhibitions">
+<BaseLayout title="Exhibitions · WOO HANNAH" description={pageDescription} schema={pageSchema}>
   <div class="mb-12 pb-8">
     <h1 class="page-title mb-8 text-3xl font-bold">Exhibitions</h1>
 

--- a/src/pages/press.astro
+++ b/src/pages/press.astro
@@ -2,6 +2,7 @@
 import BaseLayout from "../layouts/BaseLayout.astro"
 import { loadAllContent } from "../lib/content"
 import { fetchOgImage, extractFirstLink } from "../lib/og-image"
+import { absoluteUrl, breadcrumbSchema, collectionPageSchema, stripHtml, truncateText } from "../lib/seo"
 
 const all = await loadAllContent()
 const press = all.find((e) => e.type === "page" && e.slug[0] === "press")
@@ -56,6 +57,25 @@ await Promise.all(
   }),
 )
 
+const pageDescription = press.description ?? "Press coverage, interviews, articles, and external references for Woo Hannah."
+const pageSchema = [
+  collectionPageSchema({
+    name: "Press coverage for Woo Hannah",
+    description: pageDescription,
+    path: "/press/",
+    items: items.map((item) => ({
+      name: item.title,
+      url: item.firstLinkUrl ?? absoluteUrl("/press/"),
+      description: truncateText(stripHtml(item.html), 180),
+      image: item.thumbnail ? absoluteUrl(item.thumbnail) : undefined,
+    })),
+  }),
+  breadcrumbSchema([
+    { name: "Home", path: "/" },
+    { name: "Press", path: "/press/" },
+  ]),
+]
+
 /* 벤토 그리드 크기: 이미지 수에 따라 카드 크기 결정 */
 const gridClasses: string[] = []
 let multiToggle = 0
@@ -79,7 +99,7 @@ if (smallCount > 0 && smallCount % 3 === 1) {
 }
 ---
 
-<BaseLayout title="Press · WOO HANNAH">
+<BaseLayout title="Press · WOO HANNAH" description={pageDescription} schema={pageSchema}>
   <h1 class="page-title mb-10 text-3xl font-bold">Press</h1>
 
   <!-- Bento Grid -->

--- a/src/pages/thoughts/[...slug].astro
+++ b/src/pages/thoughts/[...slug].astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro"
 import { loadAllContent } from "../../lib/content"
-import { articleSchema, summarizeEntry } from "../../lib/seo"
+import { articleSchema, entryBreadcrumbSchema, summarizeEntry } from "../../lib/seo"
 
 export async function getStaticPaths() {
   const all = await loadAllContent()
@@ -14,6 +14,7 @@ export async function getStaticPaths() {
 
 const { entry } = Astro.props
 const description = summarizeEntry(entry)
+const pageSchema = [articleSchema(entry), entryBreadcrumbSchema(entry)]
 ---
 
 <BaseLayout
@@ -21,7 +22,7 @@ const description = summarizeEntry(entry)
   description={description}
   image={entry.thumbnail}
   type="article"
-  schema={articleSchema(entry)}
+  schema={pageSchema}
 >
   <article class="prose prose-zinc max-w-none">
     <h1>{entry.title}</h1>

--- a/src/pages/thoughts/index.astro
+++ b/src/pages/thoughts/index.astro
@@ -1,9 +1,23 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro"
 import { loadAllContent, sortByDateDesc } from "../../lib/content"
+import { breadcrumbSchema, collectionPageSchema, entryListItem } from "../../lib/seo"
 
 const all = await loadAllContent()
 const thoughts = sortByDateDesc(all.filter((e) => e.type === "thought"))
+const pageDescription = "Criticism, interviews, artist notes, and writing related to Woo Hannah."
+const pageSchema = [
+  collectionPageSchema({
+    name: "Thoughts on Woo Hannah",
+    description: pageDescription,
+    path: "/thoughts/",
+    items: thoughts.map((entry) => entryListItem(entry, 220)),
+  }),
+  breadcrumbSchema([
+    { name: "Home", path: "/" },
+    { name: "Thoughts", path: "/thoughts/" },
+  ]),
+]
 const baseRaw = import.meta.env.BASE_URL
 const base = baseRaw.endsWith("/") ? baseRaw : `${baseRaw}/`
 
@@ -18,7 +32,7 @@ function getExcerpt(html: string, maxLen = 200): string {
 }
 ---
 
-<BaseLayout title="Thoughts · WOO HANNAH" description="비평, 인터뷰, 작가노트">
+<BaseLayout title="Thoughts · WOO HANNAH" description={pageDescription} schema={pageSchema}>
   <div class="mb-8 border-b border-zinc-200 pb-4">
     <h1 class="page-title text-3xl font-bold">Thoughts</h1>
     <p class="mt-2 text-sm text-zinc-500">비평, 인터뷰, 작가노트</p>

--- a/src/pages/works/[...slug].astro
+++ b/src/pages/works/[...slug].astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro"
 import { loadAllContent } from "../../lib/content"
-import { summarizeEntry, visualArtworkSchema } from "../../lib/seo"
+import { entryBreadcrumbSchema, summarizeEntry, visualArtworkSchema } from "../../lib/seo"
 
 export async function getStaticPaths() {
   const all = await loadAllContent()
@@ -14,13 +14,14 @@ const description = summarizeEntry(
   entry,
   [entry.title, "by Woo Hannah", entry.year, entry.category, entry.medium].filter(Boolean).join(" · "),
 )
+const pageSchema = [visualArtworkSchema(entry), entryBreadcrumbSchema(entry)]
 ---
 
 <BaseLayout
   title={`${entry.title} · WOO HANNAH`}
   description={description}
   image={entry.thumbnail}
-  schema={visualArtworkSchema(entry)}
+  schema={pageSchema}
 >
   <article class="prose prose-zinc max-w-none work-detail">
     <h1>{entry.title}</h1>

--- a/src/pages/works/index.astro
+++ b/src/pages/works/index.astro
@@ -1,16 +1,30 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro"
 import { loadAllContent, sortByDateDesc, groupWorksBySeries } from "../../lib/content"
+import { breadcrumbSchema, collectionPageSchema, entryListItem } from "../../lib/seo"
 
 const all = await loadAllContent()
 const rawWorks = sortByDateDesc(all.filter((e) => e.type === "work"))
 const groupedWorks = groupWorksBySeries(rawWorks)
+const pageDescription = "Sculptures, installations, paintings, and textile-based mixed media works by Woo Hannah."
+const pageSchema = [
+  collectionPageSchema({
+    name: "Works by Woo Hannah",
+    description: pageDescription,
+    path: "/works/",
+    items: rawWorks.map((entry) => entryListItem(entry)),
+  }),
+  breadcrumbSchema([
+    { name: "Home", path: "/" },
+    { name: "Works", path: "/works/" },
+  ]),
+]
 
 const baseRaw = import.meta.env.BASE_URL
 const base = baseRaw.endsWith("/") ? baseRaw : `${baseRaw}/`
 ---
 
-<BaseLayout title="Works · WOO HANNAH" description="Works">
+<BaseLayout title="Works · WOO HANNAH" description={pageDescription} schema={pageSchema}>
   <div class="mb-8 pb-4">
     <h1 class="page-title text-3xl font-bold">Works</h1>
   </div>


### PR DESCRIPTION
## Summary
- Add reusable `CollectionPage`, `ItemList`, `BreadcrumbList`, and `ProfilePage` schema helpers.
- Mark Works, Exhibitions, Thoughts, and Press as structured collections with item lists.
- Add breadcrumb JSON-LD to work, exhibition, and thought detail pages.
- Add About/ProfilePage schema to strengthen the artist entity page.
- Link detail schemas back to their parent collections with `isPartOf`.

## Test Plan
- Not run locally: shell execution is unavailable in this Codex environment.
- Validation path: Vercel preview/build status on the PR commit.