### PR TITLE
[codex] Fix mobile prose overflow

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -150,6 +150,11 @@
 article.prose p {
   text-wrap: pretty;
   word-break: keep-all;
+  overflow-wrap: anywhere;
+}
+
+article.prose :where(a, li, h1, h2, h3, h4, h5, h6, figcaption) {
+  overflow-wrap: anywhere;
 }
 
 article.prose :where(h1) {


### PR DESCRIPTION
## Summary

Fixes mobile horizontal overflow on long prose pages such as `/about/`.

The rendered content uses `word-break: keep-all` for Korean prose, which preserves more natural Korean line breaks but can leave mixed Korean/English text, linked exhibition names, headings, or captions without a safe emergency break point. On narrow mobile viewports this allowed a long text run in the About page to expand the document scroll width.

This change keeps the existing Korean line-breaking behavior and adds `overflow-wrap: anywhere` to prose paragraphs plus common rich-text children that can contain long inline content.

## Validation

- `npm run build` passed locally before committing this change.
- Verified production preview with a 390px mobile viewport:
  - `/about/` Korean content: `scrollWidth` matched viewport width.
  - `/about/` English tab: `scrollWidth` matched viewport width.
  - Representative exhibition and thought detail pages had no horizontal overflow.

After the commit, a repeated local build attempt failed with `ENOSPC: no space left on device` while copying large public images into `dist`; this was an environment disk-space failure, not a code/build error.
